### PR TITLE
story/24672 - Add Support for Setting Carrier & Number Type

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -620,15 +620,47 @@
 			"help": "Add numbers to the account.",
 			"dialog": {
 				"title": "Add your phone numbers to the platform",
-				"fieldText": "Input numbers to be imported",
+				"fieldText1": "Use the form below to add numbers to the platform.",
+				"fieldText2": "Numbers should be entered in e164 format with no space.",
 				"beginImport": "Begin Import",
-				"help1": "Format Example: +14157775555 (+[country code][phone number])",
+				"help1": "Format Example: +443332420042 (+[country code][phone number])",
 				"help2": "** If importing multiple numbers, each number must be separated by a space.",
-				"invalidNumbers": "We couldn't find any valid phone number to add to the system in the list of numbers you submitted.",
+				"invalidNumbers1": "Please ensure the number(s) being added are formatted correctly as e164. If a DDI Range is being added please ensure the Quantity has been set.",
+				"invalidNumbers2": "Please ensure all fields on the form have been populated.",
 				"forceActivate": {
 					"text": "Add and assign to account",
 					"help": "Unchecking this will only add the numbers to the numbers pool, so they can be purchased via the Number Search tool. Checking the box will add the numbers and purchase them immediately."
 				}
+			},
+			"carrier": {
+				"label": "Carrier",
+				"carrierHelp": "Select the carrier the number(s) being added is provided by."
+			},
+			"numberType": {
+				"type": "Type",
+				"snddi": "Single Number DDI",
+				"range": "DDI Range",
+				"rangeStart": "First Number",
+				"rangeQty": "Quantity",
+				"rangeQtyError": "Please enter a number between 1 and 100.",
+				"numberSingle": "Number",
+				"typeHelp": "Select from either Single Number DDI or DDI Range. When selecting DDI Range the numbers must be sequential.",
+				"singleHelp": "Enter the phone number you wish to add.",
+				"rangeStartHelp": "Enter the first number of the sequential DDI Range you wish to add.",
+				"rangeQtyHelp": "Enter the total quantity of the sequentuial DDI Range you wish to add."
+
+			},
+			"numberSource": {
+				"source": "Source",
+				"classification": "Classification",
+				"default": "Default",
+				"ported_in": "Ported In",
+				"new_provide": "New Provide",
+				"geographic": "Geographic (01/02/03)",
+				"non_geographic": "Non-Geographic",
+				"premium": "Premium",
+				"sourceHelp": "Specify if the number(s) being added is being ported in, or if it's a new provide.",
+				"classificationHelp": "Specify the classification of the number(s) being added."
 			},
 			"__comment": "UI-2651: adding carrier selection to add numbers",
 			"__version": "4.1",
@@ -652,7 +684,7 @@
 				"label": "State",
 				"default": "Default",
 				"defaultHelp": "By letting this option to default, it will create numbers with the default state used by the back-end."
-			}
+			}			
 		},
 
 		"__comment": "UI-1935: Properly display a description next to a used number",

--- a/submodules/numbers/views/addExternal.html
+++ b/submodules/numbers/views/addExternal.html
@@ -2,19 +2,73 @@
 	<form id="form_add_numbers">
 		<div class="control-group">
 			<label class="control-label" for="list-numbers">
-				{{ i18n.numbers.addExternal.dialog.fieldText }}
+				<div>
+					{{ i18n.numbers.addExternal.dialog.fieldText1 }}
+				</div>
+				<div class="help-text">
+					{{ i18n.numbers.addExternal.dialog.fieldText2 }}
+				</div>
 				<div class="help-text">
 					{{ i18n.numbers.addExternal.dialog.help1 }}
 				</div>
 			</label>
 
+			<!--
 			<div class="controls">
 				<textarea name="numbers" class="list-numbers"></textarea>
 				<div class="help-text">
 					{{ i18n.numbers.addExternal.dialog.help2 }}
 				</div>
 			</div>
+			-->
 
+			<div style="padding-top: 20px;"></div>
+
+			<div class="customize-number-field">
+				<label class="popup-label" for="allowed_carriers" style="width: 100px;">{{i18n.numbers.addExternal.carrier.label}}<i class="help-popover fa fa-question-circle fa-lg" data-original-title="{{i18n.numbers.addExternal.carrier.carrierHelp}}" data-placement="right" data-toggle="tooltip"></i></label>
+				<select class="input-large" id="allowed_carriers" name="allowed-carrier">
+					{{#each allowedCarriers}}
+						<option value="{{this}}">{{this}}</option>
+					{{/each}}
+				</select>
+			</div>
+
+			<div class="customize-number-field">
+				<label class="popup-label" for="number_source" style="width: 100px;">{{i18n.numbers.addExternal.numberSource.source}}<i class="help-popover fa fa-question-circle fa-lg" data-original-title="{{i18n.numbers.addExternal.numberSource.sourceHelp}}" data-placement="right" data-toggle="tooltip"></i></label>
+				<select class="input-large" id="number_source" name="number-source">
+					<option></option>
+					<option value="ported_in">{{ i18n.numbers.addExternal.numberSource.ported_in }}</option>
+					<option value="new_provide">{{ i18n.numbers.addExternal.numberSource.new_provide }}</option>
+				</select>
+				<label class="popup-label" for="number_classification" style="width: 100px; padding-left: 10px;">{{i18n.numbers.addExternal.numberSource.classification}}<i class="help-popover fa fa-question-circle fa-lg" data-original-title="{{i18n.numbers.addExternal.numberSource.classificationHelp}}" data-placement="right" data-toggle="tooltip"></i></label>
+				<select class="input-large" id="number_classification" name="number-type">
+					<option></option>
+					<option value="geographic">{{ i18n.numbers.addExternal.numberSource.geographic }}</option>
+					<option value="non_geographic">{{ i18n.numbers.addExternal.numberSource.non_geographic }}</option>
+				</select>
+			</div>
+
+			<div class="customize-number-field" id="customize_number_type">
+				<label class="popup-label" for="number_type" style="width: 100px;">{{i18n.numbers.addExternal.numberType.type}}<i class="help-popover fa fa-question-circle fa-lg" data-original-title="{{i18n.numbers.addExternal.numberType.typeHelp}}" data-placement="right" data-toggle="tooltip"></i></label>
+				<select class="input-large" id="number_type" name="number-type">
+					<option></option>
+					<option value="snddi">{{ i18n.numbers.addExternal.numberType.snddi }}</option>
+					<option value="range">{{ i18n.numbers.addExternal.numberType.range }}</option>
+				</select>
+			</div>
+
+			<div class="customize-number-field" id="customize_number_single">
+				<label class="popup-label" for="number_single" style="width: 100px;">{{i18n.numbers.addExternal.numberType.numberSingle}}<i class="help-popover fa fa-question-circle fa-lg" data-original-title="{{i18n.numbers.addExternal.numberType.singleHelp}}" data-placement="right" data-toggle="tooltip"></i></label>
+				<input type="text" style="width: 196px;" id="number_single" name="number-single"/>
+			</div>
+
+			<div class="customize-number-field" id="customize_number_range">
+				<label class="popup-label" for="number_range_start" style="width: 100px;">{{i18n.numbers.addExternal.numberType.rangeStart}}<i class="help-popover fa fa-question-circle fa-lg" data-original-title="{{i18n.numbers.addExternal.numberType.rangeStartHelp}}" data-placement="right" data-toggle="tooltip"></i></label>
+				<input type="text" style="width: 196px;" id="number_range_start" name="number-range-start" />
+				<label class="popup-label" for="number_range_quantity" style="width: 100px; padding-left: 10px;">{{i18n.numbers.addExternal.numberType.rangeQty}}<i class="help-popover fa fa-question-circle fa-lg" data-original-title="{{i18n.numbers.addExternal.numberType.rangeQtyHelp}}" data-placement="right" data-toggle="tooltip"></i></label>
+				<input type="number" style="width: 196px;" id="number_range_quantity" name="number-range-quantity" min="1" max="100" />
+			</div>
+			
 			{{#if isAllowedToPickCarrier}}
 				<div class="customize-number-field{{#unless isAllowedToPickState}} disabled{{/unless}}">
 					<label class="popup-label" for="number_state">{{i18n.numbers.addExternal.numberState.label}}<i class="help-popover fa fa-question-circle fa-lg" data-original-title="{{i18n.numbers.addExternal.numberState.defaultHelp}}" data-placement="right" data-toggle="tooltip"></i></label>
@@ -46,6 +100,8 @@
 			{{/if}}
 		</div>
 	</form>
+
+	<div style="padding-top: 20px;"></div>
 
 	<div class="dialog-buttons-wrapper">
 		<a class="cancel-link monster-link blue" href="javascript:void(0);">{{ i18n.cancel }}</a>


### PR DESCRIPTION
Also refactored number additions. 

Text input has been removed and replaced with several options.
When adding a DDI range the first number is entered followed by the qty. The full range is then added to Kazoo. 

![image](https://github.com/Dimensions-Technologies/monster-ui-numbers/assets/151521236/d0d02b44-9bd8-45b2-9c2e-6d07b84da3d3)

Additional properties are set on the number doc. 
